### PR TITLE
fix: typescript type resolution for newest TS+ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,13 +134,14 @@
     }
   ],
   "bin": "bin.cjs",
-  "types": "./compiled-types/",
+  "types": "./compiled-types/index.d.ts",
   "type": "module",
   "main": "edition-es2018/index.js",
   "exports": {
     "node": {
       "import": "./edition-es2018-esm/index.js",
-      "require": "./edition-es2018/index.js"
+      "require": "./edition-es2018/index.js",
+      "types": "./compiled-types/index.d.ts"
     },
     "browser": {
       "import": "./edition-browsers/index.js"


### PR DESCRIPTION
Fixes error TS 7016: Could not find a declaration file for module 'discourser' in projects running Typescript 5.5 + ESM. Have not tested in other versions or setups however this simple change should have no negative effects on any other setup.